### PR TITLE
Add expressionToString to getOtherClauses

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -207,8 +207,8 @@ class CacheKey
 
         $column = "";
 
-	if (isset($where["column"]) && $where["column"] instanceof Expression) {
-            $where["column"] = $this->expressionToString($where["column"]);
+	if (data_get($where, "column") instanceof Expression) {
+            $where["column"] = $this->expressionToString(data_get($where, "column"));
         }    
 
         $column .= isset($where["column"]) ? $where["column"] : "";

--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -206,6 +206,11 @@ class CacheKey
         $value .= $this->getValuesClause($where);
 
         $column = "";
+
+	if (isset($where["column"]) && $where["column"] instanceof Expression) {
+            $where["column"] = $this->expressionToString($where["column"]);
+        }    
+
         $column .= isset($where["column"]) ? $where["column"] : "";
         $column .= isset($where["columns"]) ? implode("-", $where["columns"]) : "";
 


### PR DESCRIPTION
Fix exception: Object of class Illuminate\Database\Query\Expression could not be converted to string

Related: https://github.com/GeneaLabs/laravel-model-caching/issues/441

 Eloquent query that caused the bug, for example:

```

$this
            ->vigilances()
            ->has('investigations', '=', 1);
```

If i try to dump $where variable and got:

```
array:5 [▼ // vendor/genealabs/laravel-model-caching/src/CacheKey.php
  "type" => "Basic"
  "column" => Illuminate\Database\Query\Expression {#4958 ▼
    #value: "(select count(*) from `investigations` inner join `investigation_vigilance` on `investigations`.`id` = `investigation_vigilance`.`investigation_id` where `vigilances`.`id` = `investigation_vigilance`.`vigilance_id` and `investigations`.`deleted_at` is null) ◀"
  }
  "operator" => "="
  "value" => Illuminate\Database\Query\Expression {#4960 ▼
    #value: 1
  }
  "boolean" => "and"
]
```
