### PR TITLE
JsonContainsKey supported

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -267,7 +267,7 @@ class CacheKey
 
     protected function getTypeClause($where) : string
     {
-        $type = in_array($where["type"], ["InRaw", "In", "NotIn", "Null", "NotNull", "between", "NotInSub", "InSub", "JsonContains", "Fulltext"])
+        $type = in_array($where["type"], ["InRaw", "In", "NotIn", "Null", "NotNull", "between", "NotInSub", "InSub", "JsonContains", "Fulltext", "JsonContainsKey"])
             ? strtolower($where["type"])
             : strtolower($where["operator"]);
 


### PR DESCRIPTION
Fix warnings with JsonContainsKey where clause

<warning> WARNING </warning> Undefined array key "operator" in vendor/genealabs/laravel-model-caching/src/CacheKey.php on line 272. <warning> DEPRECATED </warning> strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/genealabs/laravel-model-caching/src/CacheKey.php on line 272.

Add JsonContainsKey type