### PR TITLE
Ensure isCachable in checkCooldownAndFlushAfterPersisting

### DIFF
--- a/src/Traits/Caching.php
+++ b/src/Traits/Caching.php
@@ -263,6 +263,10 @@ trait Caching
 
     protected function checkCooldownAndFlushAfterPersisting(Model $instance, string $relationship = "")
     {
+        if (!$this->isCachable()) {
+            return;
+        }
+
         [$cacheCooldown, $invalidatedAt] = $instance->getModelCacheCooldown($instance);
 
         if (! $cacheCooldown) {
@@ -295,6 +299,10 @@ trait Caching
         $isCacheDisabled = ! Container::getInstance()
             ->make("config")
             ->get("laravel-model-caching.enabled");
+        if ($isCacheDisabled) {
+            return false;
+        }
+
         $allRelationshipsAreCachable = true;
 
         if (
@@ -327,7 +335,6 @@ trait Caching
         }
 
         return $this->isCachable
-            && ! $isCacheDisabled
             && $allRelationshipsAreCachable;
     }
 


### PR DESCRIPTION
When MODEL_CACHE_ENABLED is set to false, checkCooldownAndFlushAfterPersisting is still running logic which opens a cache connection.

`[2024-02-25 04:34:58] local.ERROR: No connection could be made because the target machine actively refused it {"exception":"[object] (RedisException(code: 0): No connection could be made because the target machine actively refused it at \\vendor\\laravel\\framework\\src\\Illuminate\\Redis\\Connectors\\PhpRedisConnector.php:159)
[stacktrace]
#0 \\vendor\\laravel\\framework\\src\\Illuminate\\Redis\\Connectors\\PhpRedisConnector.php(159): Redis->connect('127.0.0.1', '6379', 0.0, NULL, 0, 0.0)
#1 \\vendor\\laravel\\framework\\src\\Illuminate\\Redis\\Connectors\\PhpRedisConnector.php(88): Illuminate\\Redis\\Connectors\\PhpRedisConnector->establishConnection(Object(Redis), Array)
#2 \\vendor\\laravel\\framework\\src\\Illuminate\\Support\\helpers.php(307): Illuminate\\Redis\\Connectors\\PhpRedisConnector->Illuminate\\Redis\\Connectors\\{closure}(Object(Redis))
#3 \\vendor\\laravel\\framework\\src\\Illuminate\\Redis\\Connectors\\PhpRedisConnector.php(129): tap(Object(Redis), Object(Closure))
#4 \\vendor\\laravel\\framework\\src\\Illuminate\\Redis\\Connectors\\PhpRedisConnector.php(34): Illuminate\\Redis\\Connectors\\PhpRedisConnector->createClient(Array)
#5 \\vendor\\laravel\\framework\\src\\Illuminate\\Redis\\Connectors\\PhpRedisConnector.php(38): Illuminate\\Redis\\Connectors\\PhpRedisConnector->Illuminate\\Redis\\Connectors\\{closure}()
#6 \\vendor\\laravel\\framework\\src\\Illuminate\\Redis\\RedisManager.php(112): Illuminate\\Redis\\Connectors\\PhpRedisConnector->connect(Array, Array)
#7 \\vendor\\laravel\\framework\\src\\Illuminate\\Redis\\RedisManager.php(91): Illuminate\\Redis\\RedisManager->resolve('models')
#8 \\vendor\\laravel\\framework\\src\\Illuminate\\Cache\\RedisStore.php(330): Illuminate\\Redis\\RedisManager->connection('models')
#9 \\vendor\\laravel\\framework\\src\\Illuminate\\Cache\\RedisTagSet.php(43): Illuminate\\Cache\\RedisStore->connection()
#10 \\vendor\\laravel\\framework\\src\\Illuminate\\Collections\\LazyCollection.php(789): Illuminate\\Cache\\RedisTagSet->Illuminate\\Cache\\{closure}()
#11 [internal function]: Illuminate\\Support\\LazyCollection->Illuminate\\Support\\{closure}()
#12 \\vendor\\laravel\\framework\\src\\Illuminate\\Collections\\LazyCollection.php(1297): Generator->valid()
#13 \\vendor\\laravel\\framework\\src\\Illuminate\\Cache\\RedisTaggedCache.php(129): Illuminate\\Support\\LazyCollection->Illuminate\\Support\\{closure}()
#14 \\vendor\\laravel\\framework\\src\\Illuminate\\Cache\\RedisTaggedCache.php(112): Illuminate\\Cache\\RedisTaggedCache->flushValues()
#15 \\vendor\\genealabs\\laravel-model-caching\\src\\Traits\\Caching.php(115): Illuminate\\Cache\\RedisTaggedCache->flush()
#16 \\vendor\\genealabs\\laravel-model-caching\\src\\Traits\\Caching.php(269): \\Models\\Permission->flushCache()`