### PR TITLE
Fixes `query` attribute not existing under strict mode

### DIFF
--- a/src/Traits/ModelCaching.php
+++ b/src/Traits/ModelCaching.php
@@ -22,6 +22,11 @@ trait ModelCaching
                 ?? 0;
         }
 
+        if ($key === 'query') {
+            return $this->query
+                ?? $this->newModelQuery();
+        }
+
         return parent::__get($key);
     }
 


### PR DESCRIPTION
When saving a model and `Model::shouldBeStrict()` is enabled, or to be more precise `Model::preventAccessingMissingAttributes()`, the `$query` attribute will not be accessible with the following error:
```
The attribute [query] either does not exist or was not retrieved for model [App\Models\ExampleModel].
{"userId":1,"exception":"[object] (Illuminate\\Database\\Eloquent\\MissingAttributeException(code: 0): 
The attribute [query] either does not exist or was not retrieved for model [App\\Models\\ExampleModel]. 
at /app/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:475)
```

This PR should fix this issue without impacting any functionality. Will solve #437.