### PR TITLE
[Fix] Carbon v3 new method default parameter compatibility

### DIFF
--- a/src/Traits/Caching.php
+++ b/src/Traits/Caching.php
@@ -241,7 +241,7 @@ trait Caching
 
         if (
             ! $cacheCooldown
-            || (new Carbon)->now()->diffInSeconds($invalidatedAt) < $cacheCooldown
+            || (new Carbon)->now()->diffInSeconds($invalidatedAt, true) < $cacheCooldown
         ) {
             return;
         }
@@ -285,7 +285,7 @@ trait Caching
 
         $this->setCacheCooldownSavedAtTimestamp($instance);
 
-        if ((new Carbon)->now()->diffInSeconds($invalidatedAt) >= $cacheCooldown) {
+        if ((new Carbon)->now()->diffInSeconds($invalidatedAt, true) >= $cacheCooldown) {
             $instance->flushCache();
 
             if ($relationship) {


### PR DESCRIPTION
Takes into account Carbon v3 new default parameter value on the `diffInSeconds` method.

Carbon v2 method blueprint:
```
public function diffInSeconds($date = null, $absolute = true)
```

Carbon v3 method blueprint:
```
public function diffInSeconds($date = null, bool $absolute = false): float
```


Fixes failing tests:
https://github.com/mikebronner/laravel-model-caching/blob/a38c905790c73c43dac09790eec7f0972cd651cc/tests/Integration/CachedModelTest.php#L180