### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The following are packages we have identified as conflicting:
 - [spatie/laravel-query-builder](https://github.com/spatie/laravel-query-builder)
 - [dwightwatson/rememberable](https://github.com/dwightwatson/rememberable)
 - [kalnoy/nestedset](https://github.com/lazychaser/laravel-nestedset)
+- [laravel-adjacency-list](https://github.com/staudenmeir/laravel-adjacency-list)
 
 ### Things That Don't Work Currently
 The following items currently do no work with this package:


### PR DESCRIPTION
added "laravel-adjacency-list" to conflicting-list because:

`Trait method Staudenmeir\LaravelAdjacencyList\Eloquent\HasRecursiveRelationships::newEloquentBuilder has not been applied as App\Models\Location\Attribute::newEloquentBuilder, because of collision with GeneaLabs\LaravelModelCaching\Traits\Cachable::newEloquentBuilder `